### PR TITLE
Use pure function modifier instead of constant

### DIFF
--- a/whitepaper.md
+++ b/whitepaper.md
@@ -211,7 +211,7 @@ contract ImpureSmartContract {
 
 ```
 contract PureSmartContract {
-  function calculateTotal(uint total, uint tax, uint price, uint quantity, uint taxRate) constant
+  function calculateTotal(uint total, uint tax, uint price, uint quantity, uint taxRate) pure
               returns (uint total, uint tax) {
         total = total + price * quantity;
         tax = tax + total * taxRate / 100


### PR DESCRIPTION
Since `calculateTotal` is not accessing or modifying any of the state variables, it might be better to mark it as `pure` as per the documentation. http://solidity.readthedocs.io/en/develop/contracts.html?#pure-functions